### PR TITLE
added linking to thread libs (gcc 6 complains on ubuntu 16.10)

### DIFF
--- a/cmake/ogdf.cmake
+++ b/cmake/ogdf.cmake
@@ -21,6 +21,8 @@ else()
   unset(OGDF_LEAK_CHECK CACHE)
 endif()
 
+find_package (Threads)
+
 # find available packages for stack traces
 if(OGDF_USE_ASSERT_EXCEPTIONS)
   find_package(Libdw)
@@ -56,7 +58,7 @@ if(NOT OGDF_COMPILE_LEGACY)
   endforeach()
 endif()
 add_library(OGDF ${OGDF_SOURCES})
-target_link_libraries(OGDF COIN)
+target_link_libraries(OGDF COIN ${CMAKE_THREAD_LIBS_INIT})
 group_files(OGDF_SOURCES "ogdf")
 target_compile_features(OGDF PUBLIC cxx_range_for)
 if(COIN_EXTERNAL_SOLVER_INCLUDE_DIRECTORIES)


### PR DESCRIPTION
install/lib/libOGDF.so: error: undefined reference to 'pthread_create'