### PR TITLE
enable_language(C) before find_package (Threads)

### DIFF
--- a/cmake/ogdf.cmake
+++ b/cmake/ogdf.cmake
@@ -20,6 +20,7 @@ else()
   unset(OGDF_LEAK_CHECK CACHE)
 endif()
 
+enable_language(C)
 find_package (Threads)
 
 # find available packages for stack traces


### PR DESCRIPTION
In Ubuntu 14.04 `find_package(Threads)` requires that the C language is enabled. Otherwise, one gets this error:

```
-- Looking for include file pthread.h
CMake Error at /usr/share/cmake-2.8/Modules/CheckIncludeFiles.cmake:58 (try_compile):
  Unknown extension ".c" for file

    /home/chtz/workspace/entern/external/ogdf/build/CMakeFiles/CMakeTmp/CheckIncludeFiles.c

  try_compile() works only for enabled languages.  Currently these are:

    CXX
```